### PR TITLE
fix styles for readonly switch

### DIFF
--- a/app/scripts/directives/switchcell.html
+++ b/app/scripts/directives/switchcell.html
@@ -8,10 +8,9 @@
 </span>
   для смартадмин-->
 <span class="cell cell-switch">
-  <span class="onoffswitch">
+  <span class="onoffswitch" ng-class="{'pointer-none text-muted':cell.readOnly==true}">
       <input type="checkbox" ng-model="_value" class="onoffswitch-checkbox" id="{{id}}">
-      <label class="onoffswitch-label" for="{{id}}"
-             ng-class="{'pointer-none text-muted':cell.readOnly==true}">
+      <label class="onoffswitch-label" for="{{id}}">
           <span class="onoffswitch-inner" data-swchon-text="ON" data-swchoff-text="OFF"></span>
           <span class="onoffswitch-switch"></span>
       </label>


### PR DESCRIPTION
resolve issue [#59](https://github.com/contactless/homeui/issues/59)
readonly переключатели при отображении на больших экранах (с боковым меню) теперь отображаются с кружками контрола, как и при разрешении < 786px, на мобильных устройствах