### PR TITLE
WB#66-text_cells_value

### DIFF
--- a/app/scripts/directives/textcell.js
+++ b/app/scripts/directives/textcell.js
@@ -6,7 +6,7 @@ function textCellDirective() {
     replace: true,
     template: `
       <div>
-        <p ng-if="cell.readOnly" class="cell cell-text" type="text">{{ cell.value || 'undefined value' }}</p>
+        <p ng-if="cell.readOnly" class="cell cell-text" type="text">{{ cell.value }}</p>
         <input ng-hide="cell.readOnly" class="cell cell-text" type="text" ng-model="cell.value" explicit-changes>
       </div>
     `

--- a/app/scripts/directives/textcell.js
+++ b/app/scripts/directives/textcell.js
@@ -4,7 +4,12 @@ function textCellDirective() {
     scope: false,
     require: '^cell',
     replace: true,
-    template: '<input ng-readonly="cell.readOnly" class="cell cell-text" type="text" ng-model="cell.value" explicit-changes>'
+    template: `
+      <div>
+        <p ng-if="cell.readOnly" class="cell cell-text" type="text">{{ cell.value || 'undefined value' }}</p>
+        <input ng-hide="cell.readOnly" class="cell cell-text" type="text" ng-model="cell.value" explicit-changes>
+      </div>
+    `
   };
 }
 


### PR DESCRIPTION
resolve issue [#66](https://github.com/contactless/homeui/issues/66)
В `displayCell` для отображения значения при `displayType = text` или значения неизвестного типа используется `textcell`.
В этом компоненте добавил отображение значения текстом если cell readonly, или input'ом, если нет