### PR TITLE
WB#75-improved_devices_values_copying

### DIFF
--- a/app/scripts/controllers/devicesController.js
+++ b/app/scripts/controllers/devicesController.js
@@ -14,10 +14,6 @@ class DevicesCtrl {
 
     }
 
-    copy(device, control) {
-        if (control) this.handleData.copyToClipboard(control)
-    }
-
     redirect(contr) {
         var [device,control] = contr.split('/');
         this.$state.go('historySample', {device, control, start: '-', end: '-'})

--- a/app/scripts/controllers/webUiController.js
+++ b/app/scripts/controllers/webUiController.js
@@ -7,6 +7,8 @@ export default class WebUICtrl {
         'ngInject';
 
         this.rolesFactory = rolesFactory;
+        this.uiConfig= uiConfig;
+
         uiConfig.whenReady()
             .then((data) => {
                 this.dashboards = data.dashboards;

--- a/app/scripts/controllers/webUiController.js
+++ b/app/scripts/controllers/webUiController.js
@@ -7,8 +7,6 @@ export default class WebUICtrl {
         'ngInject';
 
         this.rolesFactory = rolesFactory;
-        this.uiConfig= uiConfig;
-
         uiConfig.whenReady()
             .then((data) => {
                 this.dashboards = data.dashboards;

--- a/app/scripts/directives/displaycell.html
+++ b/app/scripts/directives/displaycell.html
@@ -4,9 +4,9 @@
      data-cell-id="{{ cell.id }}">
     <cell-name ng-if="displayCellCtrl.shouldDisplayCellName()"
                override="displayCellCtrl.overrideName()"
-               ng-click="displayCellCtrl.copy(cell.name)"
+               ng-click="displayCellCtrl.copy(cell.id)"
                tooltip-popup-close-delay="500"
-               uib-tooltip="'{{ cell.name }}' copied to clipboard"
+               uib-tooltip="'{{ cell.id }}' copied to clipboard"
                tooltip-trigger="{
                  'outsideClick': 'mouseleave',
                  'focus': 'mouseleave'

--- a/app/scripts/directives/displaycell.html
+++ b/app/scripts/directives/displaycell.html
@@ -4,7 +4,14 @@
      data-cell-id="{{ cell.id }}">
     <cell-name ng-if="displayCellCtrl.shouldDisplayCellName()"
                override="displayCellCtrl.overrideName()"
-               ng-click="displayCellCtrl.copy(cell.name)"></cell-name>
+               ng-click="displayCellCtrl.copy(cell.name)"
+               tooltip-popup-close-delay="500"
+               uib-tooltip="'{{ cell.name }}' copied to clipboard"
+               tooltip-trigger="{
+                 'outsideClick': 'mouseleave',
+                 'focus': 'mouseleave'
+               }"
+               tooltip-class="custom-tooltip"></cell-name>
     <button title="History" class="display-cell-btn btn bg-color-blueDark txt-color-white show-on-parent-hover"
             ng-click="displayCellCtrl.redirect(cell.id)">
       <i class="glyphicon glyphicon-stats"></i>

--- a/app/scripts/directives/displaycell.html
+++ b/app/scripts/directives/displaycell.html
@@ -3,7 +3,8 @@
      ng-class="{ 'cell-error': cell.error }"
      data-cell-id="{{ cell.id }}">
     <cell-name ng-if="displayCellCtrl.shouldDisplayCellName()"
-               override="displayCellCtrl.overrideName()"></cell-name>
+               override="displayCellCtrl.overrideName()"
+               ng-click="displayCellCtrl.copy(cell.name)"></cell-name>
     <button title="History" class="display-cell-btn btn bg-color-blueDark txt-color-white show-on-parent-hover"
             ng-click="displayCellCtrl.redirect(cell.id)">
       <i class="glyphicon glyphicon-stats"></i>

--- a/app/scripts/directives/displaycell.html
+++ b/app/scripts/directives/displaycell.html
@@ -11,7 +11,7 @@
                  'outsideClick': 'mouseleave',
                  'focus': 'mouseleave'
                }"
-               tooltip-class="custom-tooltip"></cell-name>
+               tooltip-class="custom-tooltip cell-name-tooltip"></cell-name>
     <button title="History" class="display-cell-btn btn bg-color-blueDark txt-color-white show-on-parent-hover"
             ng-click="displayCellCtrl.redirect(cell.id)">
       <i class="glyphicon glyphicon-stats"></i>

--- a/app/scripts/directives/displaycell.js
+++ b/app/scripts/directives/displaycell.js
@@ -8,10 +8,11 @@ function displayCellDirective(displayCellConfig, $compile) {
       'ngInject';
       //this.$scope = $scope;
       this.cell = $scope.cell;
+      this.cell.copy = this.copy.bind(this);
       this.$state = $state;
       //console.log("+++++++++this.cell",this.cell);
 
-      //this.handleData = handleData;
+      this.handleData = handleData;
     }
 
     /*copy() {
@@ -19,6 +20,11 @@ function displayCellDirective(displayCellConfig, $compile) {
 
       if(this.parentName && this.cell.id) this.handleData.copyToClipboard(this.$scope.parentName + '/' + this.$scope.cell.id)
     }*/
+
+    copy(value) {
+      debugger
+      this.handleData.copyToClipboard(value)
+    }
 
     shouldDisplayCellName () {
       return !this.compact() &&

--- a/app/scripts/directives/displaycell.js
+++ b/app/scripts/directives/displaycell.js
@@ -22,7 +22,6 @@ function displayCellDirective(displayCellConfig, $compile) {
     }*/
 
     copy(value) {
-      debugger
       this.handleData.copyToClipboard(value)
     }
 

--- a/app/scripts/directives/rangecell.html
+++ b/app/scripts/directives/rangecell.html
@@ -1,4 +1,14 @@
-<div class="cell cell-range">
+<div
+  class="cell cell-range"
+  ng-click="cell.copy(cell.value)"
+  tooltip-popup-close-delay="500"
+  uib-tooltip="'{{ cell.value }}' copied to clipboard"
+  tooltip-trigger="{
+    'outsideClick': 'mouseleave',
+    'focus': 'mouseleave'
+  }"
+  tooltip-class="custom-tooltip"
+>
  <!-- <input ng-readonly="cell.readOnly" type="range" ng-model="target.value"
          ng-model-options="{ updateOn: 'default blur', debounce: {'default': 400, 'blur': 0} }">
 -->

--- a/app/scripts/directives/textcell.html
+++ b/app/scripts/directives/textcell.html
@@ -1,0 +1,23 @@
+<div
+  ng-click="cell.copy(cell.value)"
+  tooltip-popup-close-delay="500"
+  uib-tooltip="'{{ cell.value }}' copied to clipboard"
+  tooltip-trigger="{
+    'outsideClick': 'mouseleave',
+    'focus': 'mouseleave'
+  }"
+>
+  <p
+    ng-if="cell.readOnly"
+    class="cell cell-text"
+  >
+    {{ cell.value }}
+  </p>
+  <input
+    ng-hide="cell.readOnly"
+    ng-model="cell.value"
+    type="text"
+    class="cell cell-text"
+    explicit-changes
+  >
+</div>

--- a/app/scripts/directives/textcell.js
+++ b/app/scripts/directives/textcell.js
@@ -1,15 +1,12 @@
+import template from './textcell.html'
+
 function textCellDirective() {
   return {
     restrict: 'EA',
     scope: false,
     require: '^cell',
     replace: true,
-    template: `
-      <div>
-        <p ng-if="cell.readOnly" class="cell cell-text" type="text">{{ cell.value }}</p>
-        <input ng-hide="cell.readOnly" class="cell cell-text" type="text" ng-model="cell.value" explicit-changes>
-      </div>
-    `
+    template: template
   };
 }
 

--- a/app/scripts/directives/valuecell.html
+++ b/app/scripts/directives/valuecell.html
@@ -1,4 +1,14 @@
-<span class="cell cell-value">
+<span
+  class="cell cell-value"
+  ng-click="cell.copy(cell.value)"
+  tooltip-popup-close-delay="500"
+  uib-tooltip="'{{ cell.value }}' copied to clipboard"
+  tooltip-trigger="{
+    'outsideClick': 'mouseleave',
+    'focus': 'mouseleave'
+  }"
+  tooltip-class="custom-tooltip"
+>
   <input ng-if="cell.valueType == 'number' && !cell.readOnly" type="number"
          min="{{ cell.min }}" max="{{ cell.max }}" step="{{ cell.step }}"
          ng-model="cell.value" explicit-changes>

--- a/app/styles/css/new.css
+++ b/app/styles/css/new.css
@@ -14,6 +14,14 @@
     max-width: 300px;
 }
 
+.custom-tooltip.cell-name-tooltip {
+  left: 0% !important;
+}
+
+.custom-tooltip.cell-name-tooltip .tooltip-arrow {
+  left: 20px !important;
+}
+
 .show-on-parent-hover {
     display: none;
 }

--- a/app/views/devices.html
+++ b/app/views/devices.html
@@ -14,15 +14,8 @@
                         <h3 class="panel-title">{{ _name = dev(devId).name }}</h3>
                     </div>
                     <div class="panel-body">
-                        <div ng-repeat="cellId in dev(devId).cellIds" ng-click="$ctrl.copy(_name,cellId)">
-                            <display-cell cell="cell(cellId)"
-                                          tooltip-popup-close-delay="500"
-                                          uib-tooltip="'{{cellId}}' copied to clipboard"
-                                          tooltip-trigger="{
-                                            'outsideClick': 'mouseleave',
-                                            'focus': 'mouseleave'
-                                          }"
-                                          tooltip-class="custom-tooltip"></display-cell>
+                        <div ng-repeat="cellId in dev(devId).cellIds">
+                            <display-cell cell="cell(cellId)"></display-cell>
                         </div>
                     </div>
                     <!--<header>


### PR DESCRIPTION
resolve issue [#75](https://github.com/contactless/homeui/issues/75)

Изменил поведение копирования значений при клике на значение `displaycell` в `devices`
При клике на название канала копируется название и всплывает уведомление о копировании.
При клике на значение копируется значение и всплывает уведомление о копировании для
+ value-cell
+ text-cell
+ range-cell