### PR TITLE
WB#91_fix-nav-bar-active-items

### DIFF
--- a/app/index.ejs
+++ b/app/index.ejs
@@ -75,7 +75,7 @@
                   </li>
                   <li ng-if="isConnected()" ui-sref-active="active"
                       user-role="mtt" current-role="roles.current.role">
-                      <a data-toggle="collapse" data-target=".navbar-ex1-collapse" ui-sref="scripts"><i class="glyphicon glyphicon-file"></i> Scripts</a>
+                      <a data-toggle="collapse" data-target=".navbar-ex1-collapse" ui-sref="rules"><i class="glyphicon glyphicon-file"></i> Rules</a>
                   </li>
                   <li ui-sref-active="active">
                       <a href="javascript:" data-toggle="collapse" data-target="#settings-menu">

--- a/app/index.ejs
+++ b/app/index.ejs
@@ -99,7 +99,7 @@
                           </li>
                       </ul>
                   </li>
-                  <li ui-sref-active="help">
+                  <li ui-sref-active="active">
                       <a data-toggle="collapse" data-target=".navbar-ex1-collapse" ui-sref="help"><i class="glyphicon glyphicon-question-sign"></i> Help</a>
                   </li>
               </ul>

--- a/app/scripts/app.routes.js
+++ b/app/scripts/app.routes.js
@@ -326,8 +326,8 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
       }}
     })
   //...........................................................................
-    .state('historySample', {
-      url: '/history/{device}/{control}/{start}/{end}',
+    .state('history.sample', {
+      url: '/{device}/{control}/{start}/{end}',
       templateUrl: 'views/history.html',
       controller: 'HistoryCtrl as $ctrl',
       resolve: {

--- a/app/scripts/app.routes.js
+++ b/app/scripts/app.routes.js
@@ -203,8 +203,8 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
       controller: 'LoginCtrl as $ctrl'
     })
   //...........................................................................
-    .state('scripts', {
-      url: '/scripts',
+    .state('rules', {
+      url: '/rules',
       controller: 'ScriptsCtrl as $ctrl',
       templateUrl: 'views/scripts.html',
       resolve: {
@@ -222,15 +222,15 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
                 deferred.resolve(module);
               });
             },
-            'scripts'
+            'rules'
           );
           return deferred.promise;
         }
       }
     })
   //...........................................................................
-    .state('scriptEdit', {
-      url: '/scripts/edit/{path:.*}',
+    .state('ruleEdit', {
+      url: '/rules/edit/{path:.*}',
       templateUrl: 'views/script.html',
       controller: 'ScriptCtrl as $ctrl',
       resolve: {
@@ -257,15 +257,15 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
                 deferred_2.resolve(module_2);
               });
             },
-            'script-edit'
+            'rule-edit'
           );
           return $q.all([deferred_1.promise, deferred_2.promise]);
         }
       }
     })
   //...........................................................................
-    .state('scriptNew', {
-      url: '/scripts/new',
+    .state('ruleNew', {
+      url: '/rules/new',
       templateUrl: 'views/script.html',
       controller: 'ScriptCtrl as $ctrl',
       resolve: {
@@ -292,7 +292,7 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
                 deferred_2.resolve(module_2);
               });
             },
-            'script-edit'
+            'rule-new'
           );
           return $q.all([deferred_1.promise, deferred_2.promise]);
         }

--- a/app/scripts/app.routes.js
+++ b/app/scripts/app.routes.js
@@ -229,8 +229,8 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
       }
     })
   //...........................................................................
-    .state('ruleEdit', {
-      url: '/rules/edit/{path:.*}',
+    .state('rules.edit', {
+      url: '/edit/{path:.*}',
       templateUrl: 'views/script.html',
       controller: 'ScriptCtrl as $ctrl',
       resolve: {
@@ -257,15 +257,15 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
                 deferred_2.resolve(module_2);
               });
             },
-            'rule-edit'
+            'rules-edit'
           );
           return $q.all([deferred_1.promise, deferred_2.promise]);
         }
       }
     })
   //...........................................................................
-    .state('ruleNew', {
-      url: '/rules/new',
+    .state('rules.new', {
+      url: '/new',
       templateUrl: 'views/script.html',
       controller: 'ScriptCtrl as $ctrl',
       resolve: {
@@ -292,7 +292,7 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
                 deferred_2.resolve(module_2);
               });
             },
-            'rule-new'
+            'rules-new'
           );
           return $q.all([deferred_1.promise, deferred_2.promise]);
         }

--- a/app/scripts/controllers/devicesController.js
+++ b/app/scripts/controllers/devicesController.js
@@ -173,7 +173,7 @@ class DevicesCtrl {
 
     redirect(contr) {
         var [device,control] = contr.split('/');
-        this.$state.go('historySample', {device, control, start: '-', end: '-'})
+        this.$state.go('history.sample', {device, control, start: '-', end: '-'})
     }
 }
 

--- a/app/scripts/controllers/scriptController.js
+++ b/app/scripts/controllers/scriptController.js
@@ -71,7 +71,7 @@ class ScriptCtrl {
           if ($scope.file.isNew || pos !== null) {
             // clear pos in the url after saving to be able
             // to navigate to errors
-            $location.path("/scripts/edit/" + reply.path);
+            $location.path("/rules/edit/" + reply.path);
           } else {
             cm.focus();
             cm.setValue(cm.getValue()); // clear line classes / marks

--- a/app/scripts/directives/displaycell.js
+++ b/app/scripts/directives/displaycell.js
@@ -33,7 +33,7 @@ function displayCellDirective(displayCellConfig, $compile) {
 
     redirect(contr) {
       var [device,control] = contr.split('/');
-      this.$state.go('historySample', {device, control, start: '-', end: '-'})
+      this.$state.go('history.sample', {device, control, start: '-', end: '-'})
     }
   }
 

--- a/app/styles/css/new.css
+++ b/app/styles/css/new.css
@@ -244,3 +244,17 @@ div[uib-datepicker-popup-wrap] {
 .panel-group {
   display: flex;
 }
+
+
+.side-nav>li>ul>li>a.active::before {
+  content: "\F0D9";
+  font-family: FontAwesome;
+  display: block;
+  height: 27px;
+  line-height: normal;
+  width: 27px;
+  position: absolute;
+  right: -21px;
+  font-size: 20px;
+  color: #eee;
+}

--- a/app/views/scripts.html
+++ b/app/views/scripts.html
@@ -1,5 +1,5 @@
 <h1 class="page-header">
-    Scripts
+    Rules
 </h1>
 
 
@@ -8,7 +8,7 @@
     You cannot view this page. You can change <a ui-sref="accessLevel">access level</a>.
 </div>
 <section ng-if="$ctrl.haveRights">
-    <a ui-sref="scriptNew" ui-sref-active="active" class="btn btn-success">
+    <a ui-sref="ruleNew" ui-sref-active="active" class="btn btn-success">
         New...
     </a>
     <div class="spinner-floating">
@@ -24,7 +24,7 @@
 
             <div class="row" ng-repeat="script in $ctrl.scripts">
                 <div class="col-xs-4">
-                    <a ui-sref="scriptEdit({ path: script.virtualPath })"
+                    <a ui-sref="ruleEdit({ path: script.virtualPath })"
                        ng-hide="$ctrl.renamedScripts[$index]">
                         {{ script.virtualPath }}
                     </a>

--- a/app/views/scripts.html
+++ b/app/views/scripts.html
@@ -1,3 +1,4 @@
+<div ui-view>
 <h1 class="page-header">
     Rules
 </h1>
@@ -8,7 +9,7 @@
     You cannot view this page. You can change <a ui-sref="accessLevel">access level</a>.
 </div>
 <section ng-if="$ctrl.haveRights">
-    <a ui-sref="ruleNew" ui-sref-active="active" class="btn btn-success">
+    <a ui-sref="rules.new" ui-sref-active="active" class="btn btn-success">
         New...
     </a>
     <div class="spinner-floating">
@@ -24,7 +25,7 @@
 
             <div class="row" ng-repeat="script in $ctrl.scripts">
                 <div class="col-xs-4">
-                    <a ui-sref="ruleEdit({ path: script.virtualPath })"
+                    <a ui-sref="rules.edit({ path: script.virtualPath })"
                        ng-hide="$ctrl.renamedScripts[$index]">
                         {{ script.virtualPath }}
                     </a>
@@ -41,5 +42,4 @@
         </div>
     </div>
 </section>
-
-
+</div>

--- a/app/views/widgets.html
+++ b/app/views/widgets.html
@@ -35,7 +35,7 @@
         </td>
         <td ng-if="!row.preview" class="cell-history-col">
             <a title="History" class="cell-history"
-               ui-sref="historySample({device: row.cell.device, control: row.cell.control, start: historyStartTS(), end: '-'})"><i
+               ui-sref="history.sample({device: row.cell.device, control: row.cell.control, start: historyStartTS(), end: '-'})"><i
                     class="glyphicon glyphicon-stats"></i></a>
         </td>
         <td ng-if="!!row.widget" class="description-col" rowspan="{{ row.rowSpan }}">{{ row.widget.description }}</td>


### PR DESCRIPTION
resolve issue #91 

Для того, что-бы при открытии адресов  _scripts/new_ и _scripts/abc.js_ раздел меню scripts выделялся как активных, была добавлена иерархическая структура в объявление роутинга.
Такое-же поведение было у раздела history - _/history/deviceId/cellId/-/-_ не выделял раздел меню history как активный. Так-же исправлено.

+ Исправлен стиль раздела меню help, когда он активный - это добавило ему белую стрелочку, когда раздел выбран.
+ Добавил белую стрелочку к выбранным элементам меню второй вложенности:
![image](https://user-images.githubusercontent.com/22203119/49006710-bc2a6800-f17a-11e8-9037-c42f8203f2ba.png)
 