### PR TITLE
WB#104_range-control-fix

### DIFF
--- a/app/scripts/directives/rangecell.js
+++ b/app/scripts/directives/rangecell.js
@@ -35,17 +35,18 @@ function rangeCellDirective() {
         }
       };*/
 
-      $scope._value = isNaN($scope.cell.value)? 0 : $scope.cell.value;
-
       $scope["min"] = !cellCtrl.cell["min"]? DEFAULT_MIN : +cellCtrl.cell["min"];
       $scope["max"] = !cellCtrl.cell["max"]? DEFAULT_MAX : +cellCtrl.cell["max"];
       $scope["step"] = !cellCtrl.cell["step"]? DEFAULT_STEP : +cellCtrl.cell["step"];
 
-      // изза отсутствия debounce присваиваю значение только если отпутить ручку контрола
+      $scope.$watch(() => $scope.cell.value, value => {
+        $scope._value = isNaN(value)? 0 : value;
+      });
+
+      // из-за отсутствия debounce присваиваю значение только если отпуcтить ручку контрола
       $scope.handleUp = function() {
         $scope.cell.value = $scope._value;
       }
-
     }
   };
 }


### PR DESCRIPTION
resolve issue #104

Установил watcher на значение rangecell и в нём обновляю константу, выступающую моделью для ползунка, а не один раз при инициализации как раньше. 
Для проверки есть виртуальное устройство "range-test-device" с заголовком *Вирт. уст-во для теста range*, описано в правиле `test-chane-range-value.js`, при переключении свича в котором изменяется значение.