### PR TITLE
WB#95_SVG-dashboards-fix

### DIFF
--- a/app/scripts/directives/svgScheme.js
+++ b/app/scripts/directives/svgScheme.js
@@ -59,10 +59,12 @@ export function svgSchemeDirective($compile, DeviceData) {
             var regions = element[0].querySelectorAll("*");
             angular.forEach(regions, function (path, key) {
                 var element = angular.element(path);
-                element.attr("svg-compiled-element", "");
 
                 var desc = getDirectChild(element[0], "desc");
-                if (desc != null) {
+                if (desc != null) {         
+                    element.attr("svg-compiled-element", "");
+                    element.attr("ng-clock", "");
+
                     var attrs = parseAttrs(desc.innerHTML);
 
                     if (element[0].nodeName == 'text') {
@@ -107,7 +109,7 @@ export function svgSchemeDirective($compile, DeviceData) {
 }
 
 export  function svgCompiledElementDirective($compile) {
-     'ngInject';
+    'ngInject';
     return {
         restrict: 'A',
         scope: {
@@ -117,8 +119,9 @@ export  function svgCompiledElementDirective($compile) {
             error: "="
         },
         link: function (scope, element, attrs) {
+            scope.devicedata = scope.$parent.devicedata;
             element.removeAttr("svg-compiled-element");
-            $compile(element)(scope);
+            $compile(element)(scope); 
         }
     }
 }

--- a/app/scripts/directives/svgScheme.js
+++ b/app/scripts/directives/svgScheme.js
@@ -109,7 +109,7 @@ export function svgSchemeDirective($compile, DeviceData) {
 }
 
 export  function svgCompiledElementDirective($compile) {
-    'ngInject';
+     'ngInject';
     return {
         restrict: 'A',
         scope: {
@@ -121,7 +121,7 @@ export  function svgCompiledElementDirective($compile) {
         link: function (scope, element, attrs) {
             scope.devicedata = scope.$parent.devicedata;
             element.removeAttr("svg-compiled-element");
-            $compile(element)(scope); 
+            $compile(element)(scope);
         }
     }
 }

--- a/app/scripts/directives/svgScheme.js
+++ b/app/scripts/directives/svgScheme.js
@@ -63,7 +63,7 @@ export function svgSchemeDirective($compile, DeviceData) {
                 var desc = getDirectChild(element[0], "desc");
                 if (desc != null) {         
                     element.attr("svg-compiled-element", "");
-                    element.attr("ng-clock", "");
+                    element.attr("ng-cloak", "");
 
                     var attrs = parseAttrs(desc.innerHTML);
 


### PR DESCRIPTION
resolve issue #95

Были проблемы с тем, что из-за неверного места установки атрибута `svg-compiled-element` создавалось много лишних вложенных scop'ов с одинаковыми ключами. Добавил в scope директивы `svgCompiledElementDirective` данные из родительского scope что-бы можно было использовать баиндинг вида `ADC 5V out = {{devicedata.proxy('wb-adc/5Vout').value}} V` в тегах с директивой `svgCompiledElementDirective` 