### PR TITLE
WB#92_ng-template-loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,10 @@ build:
 install:
 	install -d -m 0777 $(DESTDIR)/var/www/css
 	install -d -m 0777 $(DESTDIR)/var/www/images
-	install -d -m 0777 $(DESTDIR)/var/www/views
 	install -d -m 0777 $(DESTDIR)/var/www/uploads
 	
 	cp -a dist/css/*.css $(DESTDIR)/var/www/css
 	cp -a dist/images/* $(DESTDIR)/var/www/images
-	cp -a dist/views/* $(DESTDIR)/var/www/views
 	cp -a dist/favicon.ico $(DESTDIR)/var/www/favicon.ico
 	cp -a dist/*.js $(DESTDIR)/var/www/
 	cp -a dist/*.svg $(DESTDIR)/var/www/

--- a/app/scripts/app.routes.js
+++ b/app/scripts/app.routes.js
@@ -1,5 +1,23 @@
 import uiRouter from 'angular-ui-router';
 
+import homeTemplateUrl from 'ngtemplate-loader!../views/home.html';
+import helpTemplateUrl from 'ngtemplate-loader!../views/help.html';
+import webUITemplateUrl from 'ngtemplate-loader!../views/web-ui.html';
+import systemTemplateUrl from 'ngtemplate-loader!../views/system.html';
+import MQTTChannelsTemplateUrl from 'ngtemplate-loader!../views/MQTTChannels.html';
+import accessLevelTemplateUrl from 'ngtemplate-loader!../views/access-level.html';
+import devicesTemplateUrl from 'ngtemplate-loader!../views/devices.html';
+import widgetsTemplateUrl from 'ngtemplate-loader!../views/widgets.html';
+import dashboardsTemplateUrl from 'ngtemplate-loader!../views/dashboards.html';
+import dashboardTemplateUrl from 'ngtemplate-loader!../views/dashboard.html';
+import settingsTemplateUrl from 'ngtemplate-loader!../views/settings.html';
+import loginTemplateUrl from 'ngtemplate-loader!../views/login.html';
+import scriptsTemplateUrl from 'ngtemplate-loader!../views/scripts.html';
+import scriptTemplateUrl from 'ngtemplate-loader!../views/script.html';
+import historyTemplateUrl from 'ngtemplate-loader!../views/history.html';
+import configsTemplateUrl from 'ngtemplate-loader!../views/configs.html';
+import configTemplateUrl from 'ngtemplate-loader!../views/config.html';
+
 function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
   'ngInject';
 
@@ -12,39 +30,39 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
   //...........................................................................
     .state('home', {
       url: '/',
-      templateUrl: 'views/home.html',
+      templateUrl: homeTemplateUrl,
       controller: 'HomeCtrl as $ctrl'
     })
       .state('help', {
           url: '/help',
-          templateUrl: 'views/help.html',
+          templateUrl: helpTemplateUrl,
           controller: 'HelpCtrl as $ctrl'
       })
       .state('webUI', {
           url: '/web-ui',
-          templateUrl: 'views/web-ui.html',
+          templateUrl: webUITemplateUrl,
           controller: 'WebUICtrl as $ctrl'
       })
       .state('system', {
           url: '/system',
-          templateUrl: 'views/system.html',
+          templateUrl: systemTemplateUrl,
           controller: 'SystemCtrl as $ctrl'
       })
       .state('MQTTChannels', {
           url: '/MQTTChannels',
-          templateUrl: 'views/MQTTChannels.html',
+          templateUrl: MQTTChannelsTemplateUrl,
           controller: 'MQTTCtrl as $ctrl'
       })
       .state('accessLevel', {
           url: '/access-level',
-          templateUrl: 'views/access-level.html',
+          templateUrl: accessLevelTemplateUrl,
           controller: 'AccessLevelCtrl as $ctrl'
       })
   //...........................................................................
     .state('devices', {
       url: '/devices',
       controller: 'DevicesCtrl as $ctrl',
-      templateUrl: 'views/devices.html',
+      templateUrl: devicesTemplateUrl,
       resolve: {
         ctrl: ($q, $ocLazyLoad) => {
           'ngInject';
@@ -70,7 +88,7 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
   .state('currentDevices', {
     url: '/devices/{deviceId}',
     controller: 'DevicesCtrl as $ctrl',
-    templateUrl: 'views/devices.html',
+    templateUrl: devicesTemplateUrl,
     resolve: {
       ctrl: ($q, $ocLazyLoad) => {
         'ngInject';
@@ -96,7 +114,7 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
     .state('widgets', {
       url: '/widgets',
       controller: 'WidgetsCtrl as $ctrl',
-      templateUrl: 'views/widgets.html',
+      templateUrl: widgetsTemplateUrl,
       resolve: {
         ctrl: ($q, $ocLazyLoad) => {
           'ngInject';
@@ -122,7 +140,7 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
     .state('dashboards', {
       url: '/dashboards',
       controller: 'DashboardsCtrl as $ctrl',
-      templateUrl: 'views/dashboards.html',
+      templateUrl: dashboardsTemplateUrl,
       resolve: {
         ctrl: ($q, $ocLazyLoad) => {
           'ngInject';
@@ -148,7 +166,7 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
     .state('dashboard', {
       url: '/dashboards/{id}',
       controller: 'DashboardCtrl as $ctrl',
-      templateUrl: 'views/dashboard.html',
+      templateUrl: dashboardTemplateUrl,
       resolve: {
         ctrl: ($q, $ocLazyLoad) => {
           'ngInject';
@@ -174,7 +192,7 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
     .state('settings', {
       url: '/settings',
       controller: 'SettingCtrl as $ctrl',
-      templateUrl: 'views/settings.html',
+      templateUrl: settingsTemplateUrl,
       resolve: {
         ctrl: ($q, $ocLazyLoad) => {
           'ngInject';
@@ -199,14 +217,14 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
   //...........................................................................
     .state('login', {
       url: '/login/{id}',
-      templateUrl: 'views/login.html',
+      templateUrl: loginTemplateUrl,
       controller: 'LoginCtrl as $ctrl'
     })
   //...........................................................................
     .state('rules', {
       url: '/rules',
       controller: 'ScriptsCtrl as $ctrl',
-      templateUrl: 'views/scripts.html',
+      templateUrl: scriptsTemplateUrl,
       resolve: {
         ctrl: ($q, $ocLazyLoad) => {
           'ngInject';
@@ -231,7 +249,7 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
   //...........................................................................
     .state('rules.edit', {
       url: '/edit/{path:.*}',
-      templateUrl: 'views/script.html',
+      templateUrl: scriptTemplateUrl,
       controller: 'ScriptCtrl as $ctrl',
       resolve: {
         ctrl: ($q, $ocLazyLoad) => {
@@ -266,7 +284,7 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
   //...........................................................................
     .state('rules.new', {
       url: '/new',
-      templateUrl: 'views/script.html',
+      templateUrl: scriptTemplateUrl,
       controller: 'ScriptCtrl as $ctrl',
       resolve: {
         ctrl: ($q, $ocLazyLoad) => {
@@ -302,7 +320,7 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
     .state('history', {
       url: '/history',
       controller: 'HistoryCtrl as $ctrl',
-      templateUrl: 'views/history.html',
+      templateUrl: historyTemplateUrl,
       resolve: {
         ctrl: ($q, $ocLazyLoad) => {
           'ngInject';
@@ -328,7 +346,7 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
   //...........................................................................
     .state('history.sample', {
       url: '/{device}/{control}/{start}/{end}',
-      templateUrl: 'views/history.html',
+      templateUrl: historyTemplateUrl,
       controller: 'HistoryCtrl as $ctrl',
       resolve: {
           /*load: ['$ocLazyLoad', function($ocLazyLoad) {
@@ -360,7 +378,7 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
     .state('configs', {
       url: '/configs',
       controller: 'ConfigsCtrl as $ctrl',
-      templateUrl: 'views/configs.html',
+      templateUrl: configsTemplateUrl,
       resolve: {
         ctrl: ($q, $ocLazyLoad) => {
           'ngInject';
@@ -387,7 +405,7 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
     .state('configEdit', {
       url: '/configs/edit/{path:.*}',
       controller: 'ConfigCtrl as $ctrl',
-      templateUrl: 'views/config.html',
+      templateUrl: configTemplateUrl,
       resolve: {
         ctrl: ($q, $ocLazyLoad) => {
           'ngInject';

--- a/app/scripts/app.routes.js
+++ b/app/scripts/app.routes.js
@@ -1,22 +1,22 @@
 import uiRouter from 'angular-ui-router';
 
-import homeTemplateUrl from 'ngtemplate-loader!../views/home.html';
-import helpTemplateUrl from 'ngtemplate-loader!../views/help.html';
-import webUITemplateUrl from 'ngtemplate-loader!../views/web-ui.html';
-import systemTemplateUrl from 'ngtemplate-loader!../views/system.html';
-import MQTTChannelsTemplateUrl from 'ngtemplate-loader!../views/MQTTChannels.html';
-import accessLevelTemplateUrl from 'ngtemplate-loader!../views/access-level.html';
-import devicesTemplateUrl from 'ngtemplate-loader!../views/devices.html';
-import widgetsTemplateUrl from 'ngtemplate-loader!../views/widgets.html';
-import dashboardsTemplateUrl from 'ngtemplate-loader!../views/dashboards.html';
-import dashboardTemplateUrl from 'ngtemplate-loader!../views/dashboard.html';
-import settingsTemplateUrl from 'ngtemplate-loader!../views/settings.html';
-import loginTemplateUrl from 'ngtemplate-loader!../views/login.html';
-import scriptsTemplateUrl from 'ngtemplate-loader!../views/scripts.html';
-import scriptTemplateUrl from 'ngtemplate-loader!../views/script.html';
-import historyTemplateUrl from 'ngtemplate-loader!../views/history.html';
-import configsTemplateUrl from 'ngtemplate-loader!../views/configs.html';
-import configTemplateUrl from 'ngtemplate-loader!../views/config.html';
+import homeTemplateUrl from 'ngtemplate-loader?relativeTo=/app!../views/home.html';
+import helpTemplateUrl from 'ngtemplate-loader?relativeTo=/app!../views/help.html';
+import webUITemplateUrl from 'ngtemplate-loader?relativeTo=/app!../views/web-ui.html';
+import systemTemplateUrl from 'ngtemplate-loader?relativeTo=/app!../views/system.html';
+import MQTTChannelsTemplateUrl from 'ngtemplate-loader?relativeTo=/app!../views/MQTTChannels.html';
+import accessLevelTemplateUrl from 'ngtemplate-loader?relativeTo=/app!../views/access-level.html';
+import devicesTemplateUrl from 'ngtemplate-loader?relativeTo=/app!../views/devices.html';
+import widgetsTemplateUrl from 'ngtemplate-loader?relativeTo=/app!../views/widgets.html';
+import dashboardsTemplateUrl from 'ngtemplate-loader?relativeTo=/app!../views/dashboards.html';
+import dashboardTemplateUrl from 'ngtemplate-loader?relativeTo=/app!../views/dashboard.html';
+import settingsTemplateUrl from 'ngtemplate-loader?relativeTo=/app!../views/settings.html';
+import loginTemplateUrl from 'ngtemplate-loader?relativeTo=/app!../views/login.html';
+import scriptsTemplateUrl from 'ngtemplate-loader?relativeTo=/app!../views/scripts.html';
+import scriptTemplateUrl from 'ngtemplate-loader?relativeTo=/app!../views/script.html';
+import historyTemplateUrl from 'ngtemplate-loader?relativeTo=/app!../views/history.html';
+import configsTemplateUrl from 'ngtemplate-loader?relativeTo=/app!../views/configs.html';
+import configTemplateUrl from 'ngtemplate-loader?relativeTo=/app!../views/config.html';
 
 function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
   'ngInject';

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "0.0.30",
     "ng-annotate-webpack-plugin": "^0.2.1-pre",
+    "ngtemplate-loader": "^2.0.1",
     "node-libs-browser": "^2.0.0",
     "normalize.css": "^5.0.0",
     "null-loader": "^0.1.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -345,8 +345,8 @@ module.exports = function makeWebpackConfig() {
                 {from: path.join(__dirname, 'app', 'robots.txt'), to: 'robots.txt'}
             ]),
 
-            new webpack.HashedModuleIdsPlugin(),
-            new WebpackChunkHash({algorithm: 'md5'}),
+            // new webpack.HashedModuleIdsPlugin(),
+            // new WebpackChunkHash({algorithm: 'md5'}),
 
             // Allows exporting a JSON file that maps chunk ids to their resulting
             // asset files. Webpack can then read this mapping, assuming it is
@@ -354,23 +354,23 @@ module.exports = function makeWebpackConfig() {
             // chunk asset hashes) in the bootstrap script, which allows to actually
             // leverage long-term caching.
             // Reference: https://github.com/soundcloud/chunk-manifest-webpack-plugin
-            new ChunkManifestPlugin({
-                filename: 'chunk-manifest.json',
-                manifestVariable: 'webpackManifest'
-            }),
+            // new ChunkManifestPlugin({
+            //     filename: 'chunk-manifest.json',
+            //     manifestVariable: 'webpackManifest'
+            // }),
 
             // This is a webpack plugin that inline your manifest.js with a script tag to save http request.
             // Reference: https://github.com/szrenwei/inline-manifest-webpack-plugin
-            new InlineManifestWebpackPlugin({
-                name: 'webpackManifest'
-            }),
+            // new InlineManifestWebpackPlugin({
+            //     name: 'webpackManifest'
+            // }),
 
             // Inline output JSON chunck manifest from ChunkManifestPlugin into index.ejs template
-            new InlineChunksManifestPlugin({
-                name: 'chunksManifest', // asset name for accessing from HTML template
-                filename: 'chunk-manifest.json',
-                manifestVariable: 'webpackManifest'
-            }),
+            // new InlineChunksManifestPlugin({
+            //     name: 'chunksManifest', // asset name for accessing from HTML template
+            //     filename: 'chunk-manifest.json',
+            //     manifestVariable: 'webpackManifest'
+            // }),
 
             // Writes the stats of a build to a file.
             // Reference: https://github.com/unindented/stats-webpack-plugin/

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -340,7 +340,6 @@ module.exports = function makeWebpackConfig() {
             // Reference: https://github.com/kevlened/copy-webpack-plugin
             new CopyWebpackPlugin([
                 {from: path.join(__dirname, 'app', 'images'), to: 'images'},
-                {from: path.join(__dirname, 'app', 'views'), to: 'views'},
                 {from: path.join(__dirname, 'app', '404.html'), to: '404.html'},
                 {from: path.join(__dirname, 'app', 'favicon.ico'), to: 'favicon.ico'},
                 {from: path.join(__dirname, 'app', 'robots.txt'), to: 'robots.txt'}


### PR DESCRIPTION
resolve issue #92 

Добавил обработку template 'ов через [ngtemplate-loader](https://github.com/WearyMonkey/ngtemplate-loader).

Этот loader при каждой сборке приложения webpack'ом регистрирует template'ы в `angular $templateCache`. Таким образом актуальные template'ы всегда есть на стороне пользователя в `main.[content-hash].js` сборке, у которой есть content-hash в имени файла, что гарантирует актуальность отдаваемых nginx'ом данных.

Т.к. templat'ы теперь хранятся в сборке из webpack и make файлов были удалены строчки с перекладыванием `views` папки.
