### PR TITLE
add device delete btn that call mqtt.send method for all device topics

### DIFF
--- a/app/scripts/controllers/devicesController.js
+++ b/app/scripts/controllers/devicesController.js
@@ -8,6 +8,7 @@ class DevicesCtrl {
 
         this.$state = $state;
         this.handleData = handleData;
+        this.DeviceData = DeviceData;
 
         // will create object to keep devices open/close condition 
         // in localeStorage, if it's not there.
@@ -33,7 +34,15 @@ class DevicesCtrl {
             if(devicesIdsCount != this.$state.devicesIdsCount) {
                 let devicesVisibility =  JSON.parse(window.localStorage.devicesVisibility);
 
-                devicesIdsList.map((deviceId) => {
+                // check localStorage for outdated (deleted) devices 
+                Object.keys(devicesVisibility.devices).forEach((deviceId) => {
+                  if(!devicesIdsList.includes(deviceId)) {
+                    delete devicesVisibility.devices[deviceId]
+                  }
+                })
+
+                // add new devices to localStorage
+                devicesIdsList.forEach((deviceId) => {
                     if(!devicesVisibility.devices.hasOwnProperty(deviceId)) {
                         devicesVisibility.devices[deviceId] = { isOpen : false };
                     }
@@ -170,6 +179,13 @@ class DevicesCtrl {
             'glyphicon-chevron-right':  !isOpen
         }
     }
+
+    deleteDevice(deviceId) { 
+      const deviceName = this.DeviceData.devices[deviceId].name || deviceId;
+      if (confirm(`Remove '${deviceName}'?`)) {
+        this.DeviceData.deleteDevice(deviceId);
+      }  
+    } 
 
     redirect(contr) {
         var [device,control] = contr.split('/');

--- a/app/styles/css/new.css
+++ b/app/styles/css/new.css
@@ -204,6 +204,31 @@ div[uib-datepicker-popup-wrap] {
   color: white;
   padding: 0;
   border: none !important;
+  position: relative;
+}
+
+.device-panel__header-delete-button {
+  position: absolute;
+  opacity: 0;
+  top: 8px;
+  right: 40px;
+  padding: 6px;
+  font-size: 12px;
+  transition: opacity .2s;
+}
+
+.device-panel:hover .device-panel__header-delete-button {
+  opacity: 0.8;
+}
+
+.device-panel:hover .device-panel__header-delete-button:hover {
+  opacity: 1;
+}
+
+.device-panel__header-wrapper {
+  position: relative; 
+  background-color: #3276b1; 
+  color: white;
 }
 
 .device-panel__header {

--- a/app/views/devices.html
+++ b/app/views/devices.html
@@ -19,6 +19,13 @@
                       <span class="device-panel__header-title">{{ dev(deviceId).name }}</span>
                       <i class="pull-right glyphicon device-panel__header-glyphicon" ng-class="$ctrl.getDeviceShevronClasses(deviceId)"></i>
                   </div>
+                  <span
+                    ng-click="$ctrl.deleteDevice(deviceId)"
+                    title="Delete device"
+                    class="device-panel__header-delete-button"
+                  >
+                    <i class="glyphicon glyphicon-trash white"></i>
+                  </span>
                 </uib-accordion-heading>
                 <div class="device-panel__body" ng-if="$ctrl.getDeviceVisibility(deviceId).isOpen">
                     <display-cell

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.0~beta11) stable; urgency=medium
+
+  * add delete device button
+
+ -- Evgeny Boger <boger@contactless.ru>  Fri, 12 Apr 2019 23:26:01 +0300
+
 wb-mqtt-homeui (2.0~beta10) stable; urgency=medium
 
   * disable webui editing


### PR DESCRIPTION
remove mqtt.publish method because Paho.MQTT.Client does not contain it

improve deleting of the device

improve deleting of the device

delete optional comments

Revert "remove mqtt.publish method because Paho.MQTT.Client does not contain it"

This reverts commit 60f55008a6a74f6df3b2daeb0ecfa111e81529d4.

move all subscription handlers to one callback

move last handler & add en comments

returned automatically renamed function names

device deleting

up deb ver